### PR TITLE
forward 9200->9200; install es from rpm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
 
   # port forwarding
   config.vm.network :forwarded_port, guest: 80, host: 8080
-  config.vm.network :forwarded_port, guest: 9200, host: 8081
+  config.vm.network :forwarded_port, guest: 9200, host: 9200
 
   # up memory (elasticsearch is a memory hog)
   config.vm.provider :virtualbox do |vb|

--- a/provision.py
+++ b/provision.py
@@ -2,33 +2,38 @@
 import os
 from os.path import join
 from os import path
-from subprocess import call, Popen
-import settings
-import time
+from subprocess import call
 
 DIR = path.dirname(path.realpath(__file__))
 
-try:
-    call('sudo yum update -y'.split())
-    #install java
-    call('sudo yum install java-1.7.0-openjdk-devel -y'.split())
-    # install dev packages
-    call('sudo yum install git gcc python-pip python-devel.x86_64 libxslt-devel.x86_64 libxslt-python.x86_64 libxml2-devel.x86_64 libxml2-python.x86_64 -y'.split())
-    # add EPEL repo
-    call('sudo rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm'.split())
-    # install nginx
-    call('sudo yum install -y nginx'.split())
-except OSError:
-    # if yum isn't installed, need to run apt commands
-    # update and upgrade all packages
-    call('sudo apt-get update -y'.split())
-    call('sudo apt-get upgrade -y'.split())
-    # install java
-    call('sudo apt-get install curl openjdk-7-jre-headless -y'.split())
-    # install python developer packages
-    call('sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev -y'.split())
-    # install nginx
-    call('sudo apt-get install nginx'.split())
+
+call('sudo yum update -y'.split())
+#install java
+call('sudo yum install java-1.7.0-openjdk-devel -y'.split())
+# install dev packages
+call('sudo yum install wget git gcc python-pip python-devel.x86_64 libxslt-devel.x86_64 libxslt-python.x86_64 libxml2-devel.x86_64 libxml2-python.x86_64 -y'.split())
+# add EPEL repo
+call('sudo rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm'.split())
+# install nginx
+call('sudo yum install -y nginx'.split())
+
+# install elasticsearch key and repo
+call('rpm --import http://packages.elasticsearch.org/GPG-KEY-elasticsearch'.split())
+call(['sudo', 'cp', join(DIR, 'elasticsearch.repo'), '/etc/yum.repos.d/elasticsearch.repo'])
+#install elastic search
+call('sudo yum install -y elasticsearch.noarch'.split())
+
+# # if yum isn't installed, need to run apt commands - this is no longer maintained
+# # but need to update to use elasticsearch repo (http://www.elasticsearch.org/blog/apt-and-yum-repositories/)
+# # update and upgrade all packages
+# call('sudo apt-get update -y'.split())
+# call('sudo apt-get upgrade -y'.split())
+# # install java
+# call('sudo apt-get install curl openjdk-7-jre-headless -y'.split())
+# # install python developer packages
+# call('sudo apt-get install python-dev python-pip libxml2-dev libxslt1-dev -y'.split())
+# # install nginx
+# call('sudo apt-get install nginx'.split())
 
 # copy over nginx config file
 with open(join(DIR, 'nginx.conf.template'), 'r') as conf_file:
@@ -48,33 +53,10 @@ call('sudo service nginx start'.split())
 # start on startup
 call('sudo chkconfig nginx on'.split())
 
-#install elastic search
-if 'elasticsearch-1.0.0.tar.gz' not in os.listdir(DIR):
-    call(['wget', 'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.0.0.tar.gz'])
-    call(['tar', '-xvzf', join(DIR, 'elasticsearch-1.0.0.tar.gz')])
+call('sudo service elasticsearch start'.split())
 
-# start elasticsearch
-Popen(join(DIR, 'elasticsearch-1.0.0/bin/elasticsearch'))
+# start on startup
+call('sudo chkconfig elasticsearch on'.split())
 
 # install python dependencies
 call('sudo pip install -r requirements.txt'.split())
-
-import requests
-
-# wait until elasticsearch is started up
-while True:
-    print("waiting for elasticsearch to start...")
-    try:
-        requests.get(settings.ES_HOST)
-    except requests.exceptions.ConnectionError:
-        time.sleep(2)
-    else:
-        break
-print("elastic search started")
-
-# create wiki index with schema
-with open(join(DIR, 'schema_page.json')) as f:
-    schema = f.read()
-
-requests.put(settings.ES_HOST + '/wiki', data=schema)
-


### PR DESCRIPTION
forward elasticsearch from 9200->9200, rather than 8081

install elasticsearch from repo provided by elasticsearch.

got rid of apt-get installation.

removed schema installations since that is done by sync.py now.
