### PR TITLE
Github issues and comment

### DIFF
--- a/server/index.py
+++ b/server/index.py
@@ -58,7 +58,7 @@ def index_ghe_repos(repo_names=None, force=False):
     jobs = [pool.spawn(indexers.wiki, 'GHE', repo_name, ghe_pool, force) for repo_name in repo_names]
     jobs += [pool.spawn(indexers.readme, 'GHE', repo_name, ghe_pool, force) for repo_name in repo_names]
     jobs = [pool.spawn(indexers.gh_pages, 'GHE', repo_name, pages_pool, force) for repo_name in repo_names]
-    jobs = [pool.spawn(indexers.gh_issues, 'GHE', ghe_api_client, repo_name, force) for repo_name in repo_names]
+    jobs = [pool.spawn(indexers.gh_issues, 'GHE', ghe_api_client, repo_name) for repo_name in repo_names]
     return jobs
 
 def index_gh_repos(repo_names=None, force=False):
@@ -66,7 +66,7 @@ def index_gh_repos(repo_names=None, force=False):
     jobs = [pool.spawn(indexers.wiki, 'GH', repo_name, gh_pool, force) for repo_name in repo_names]
     jobs += [pool.spawn(indexers.readme, 'GH', repo_name, gh_pool, force) for repo_name in repo_names]
     jobs += [pool.spawn(indexers.gh_pages, 'GH', repo_name, pages_pool, force) for repo_name in repo_names]
-    jobs = [pool.spawn(indexers.gh_issues, 'GH', gh_api_client, repo_name, force) for repo_name in repo_names]
+    jobs = [pool.spawn(indexers.gh_issues, 'GH', gh_api_client, repo_name) for repo_name in repo_names]
     return jobs
 
 if __name__ == '__main__':

--- a/server/indexers/__init__.py
+++ b/server/indexers/__init__.py
@@ -2,3 +2,4 @@ from wiki import index as wiki
 from readme import index as readme
 from gh_pages import index as gh_pages
 from jira import index_all_jira_issues as jira_issues
+from gh_issues import index as gh_issues

--- a/server/indexers/gh_issues.py
+++ b/server/indexers/gh_issues.py
@@ -8,7 +8,7 @@ import time
 obj_type = 'gh_issue'
 
 
-def index(gh_type, client, repo_name, force=False):
+def index(gh_type, client, repo_name):
     start = time.mktime(datetime.now().timetuple())
     indexed_timestamp = helpers.get_indexed_version(gh_type, repo_name, obj_type)
     # increment timestamp by one second to prevent duplicates

--- a/server/indexers/gh_issues.py
+++ b/server/indexers/gh_issues.py
@@ -1,0 +1,95 @@
+from server.indexers import github_helpers as helpers
+from server.utils import iter_get
+
+from datetime import datetime, timedelta
+from urlparse import urlparse
+import time
+
+obj_type = 'gh_issue'
+
+
+def index(gh_type, client, repo_name, force=False):
+    start = time.mktime(datetime.now().timetuple())
+    indexed_timestamp = helpers.get_indexed_version(gh_type, repo_name, obj_type)
+    # increment timestamp by one second to prevent duplicates
+    indexed_timestamp = nudge_datetime(indexed_timestamp)
+    bulk_data = index_gh_issues(gh_type, client, repo_name, indexed_timestamp)
+    bulk_data += index_gh_issue_comments(gh_type, client, repo_name, indexed_timestamp)
+    helpers.update_repo_index(gh_type, repo_name, obj_type, bulk_data)
+    end = time.mktime(datetime.now().timetuple())
+    print '%s: %s github issues (%s secs)' % (repo_name, len(bulk_data)/2, end-start)
+
+
+def index_gh_issues(gh_type, client, repo_name, since):
+    (owner, repo) = repo_name.split('/')
+    issues = iter_get(client.repos._(owner)._(repo).issues.params(
+        state='all', since=since))
+
+    bulk_data = []
+    most_recent_timestamp = ""
+    for issue in issues:
+        index = {}
+        index["_index"] = "search"
+        index["_type"] = obj_type
+        index["_id"] = "%s/%s" % (repo_name, issue['number'])
+        obj = {}
+        obj['url'] = issue['html_url']
+        obj['title'] = issue['title']
+        obj['content'] = issue['body']
+        obj['author'] = issue['user']['login']
+        obj['updated_date'] = issue['updated_at']
+        obj['status'] = issue['state']
+        if issue['assignee']:
+            obj['assignee'] = issue['assignee']['login']
+        obj['path'] = '/' + repo_name
+        obj['loc'] = {'GH': 'github', 'GHE': 'github enterprise'}[gh_type]
+
+        bulk_data.append({'index': index})
+        bulk_data.append(obj)
+
+        if most_recent_timestamp < issue['updated_at']:
+            most_recent_timestamp = issue['updated_at']
+
+    # Update the 'latest version'
+    if most_recent_timestamp:
+        helpers.save_indexed_version(gh_type, repo_name, obj_type,
+                                     most_recent_timestamp)
+
+    return bulk_data
+
+
+def index_gh_issue_comments(gh_type, client, repo_name, since):
+    (owner, repo) = repo_name.split('/')
+    comments = iter_get(client.repos._(owner)._(repo).issues.comments.params(since=since))
+
+    bulk_data = []
+    for comment in comments:
+        # parse issue number from url
+        # example: https://api.github.com/myorg/myname/myrepo/issues/1
+        issue_id = urlparse(comment['issue_url']).path.split('/')[-1]
+
+        index = {}
+        index["_index"] = "search"
+        index["_type"] = obj_type
+        index["_id"] = "%s/%s/%s" % (repo_name, issue_id, comment['id'])
+        obj = {}
+        obj['url'] = comment['html_url']
+        obj['title'] = 'Comment for %s issue %s' % (repo_name, issue_id)
+        obj['content'] = comment['body']
+        obj['author'] = comment['user']['login']
+        obj['updated_date'] = comment['updated_at']
+        obj['path'] = '/%s/%s' % (repo_name, issue_id)
+        obj['loc'] = {'GH': 'github', 'GHE': 'github enterprise'}[gh_type]
+
+        bulk_data.append({'index': index})
+        bulk_data.append(obj)
+
+    return bulk_data
+
+
+# Move time ahead one second
+def nudge_datetime(timestamp):
+    if timestamp:
+        datetime_obj = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+        datetime_obj = datetime_obj + timedelta(seconds=1)
+        return datetime_obj.strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,0 +1,16 @@
+#! /usr/bin/python
+
+
+def iter_get(client):
+    """
+    return an iterator over all results from GETing the client and any subsequent pages.
+    """
+    items = []
+    while items or client:
+        if not items:
+            resp = client.get()
+            items = resp.json()
+            next = resp.links.get('next', {}).get('url')
+            client = client._path([next]) if next else None
+        if items:
+            yield(items.pop(0))


### PR DESCRIPTION
* Add functions to pull github issue and issue comments
* Move `iter_get` to generic `utils.py` file so it can be used outside index.py

On my sample enterprise github, i was able to export 48,000 comments and issues in less than 3 minutes on my laptop.

Note - I looked into using gevent to do issues and comments in parallel but didn't see much improvement (if any) on the small sample set.  Need to investigate with a larger sample set.