### PR TITLE
autocomplete schema fix

### DIFF
--- a/server/schemas/autocomplete.json
+++ b/server/schemas/autocomplete.json
@@ -30,16 +30,16 @@
           "search_analyzer": "standard",
           "store": "no"
         }
-      },
-      "user": {
-        "properties": {
-          "user": {
-            "type": "string",
-            "index_analyzer": "autocomplete",
-            "index": "analyzed",
-            "search_analyzer": "standard",
-            "store": "no"
-          }
+      }
+    },
+    "user": {
+      "properties": {
+        "user": {
+          "type": "string",
+          "index_analyzer": "autocomplete",
+          "index": "analyzed",
+          "search_analyzer": "standard",
+          "store": "no"
         }
       }
     }


### PR DESCRIPTION
Due to an error in the schema, queries matching the ngrams that were indexed for autocomplete fields were not returning results. 